### PR TITLE
Import all the env variables prefixed with 'CARAVEL_'

### DIFF
--- a/caravel/caravel_config.py
+++ b/caravel/caravel_config.py
@@ -23,3 +23,8 @@ CSRF_ENABLED = os.getenv('CSRF_ENABLED', '1') in ('True', 'true', '1')
 
 # Whether to run the web server in debug mode or not
 DEBUG = os.getenv('DEBUG', '1') in ('True', 'true', '1')
+
+# Import all the env variables prefixed with 'CARAVEL_'
+config_keys = [c for c in os.environ if c.startswith('CARAVEL_')]
+for key in config_keys:
+    globals()[key[8:]] = os.environ[key]


### PR DESCRIPTION
This will make the docker image more flexible. For example:

```
docker run --detach --name caravel \
    --env SECRET_KEY="mySUPERsecretKEY" \
    --env SQLALCHEMY_DATABASE_URI="postgresql://user:pass@host:port/db" \
    --env CARAVEL_LOG_LEVEL="DEBUG"
    --env CARAVEL_CACHE_DEFAULT_TIMEOUT=1234
    --env CARAVEL_BABEL_DEFAULT_LOCALE = 'es'
    --publish 8088:8088 \
    amancevice/caravel
```

the older environment variables (SQLALCHEMY_DATABASE_URI, SECRET_KEY...) could be removed, but it makes sense to leave them there for backward compatibility
