### PR TITLE
Fix Readme for mounting Caravel SQLite DB to host

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker run --detach --name caravel \
     --env SECRET_KEY="mySUPERsecretKEY" \
     --env SQLALCHEMY_DATABASE_URI="sqlite:////home/caravel/caravel.db" \
     --publish 8088:8088 \
-    --volume ~/caravel/caravel.db:/home/caravel/caravel.db \
+    --volume ~/caravel/:/home/caravel/ \
     amancevice/caravel
 ```
 


### PR DESCRIPTION
Docker kept throwing the following error message when I tried running the container for a SQLite setup:

`[9] System error: not a directory.`

Rather than mounting the path to the SQLite DB, I have mounted the path to the directory. 

Does this look right to you guys too?
